### PR TITLE
Kwalitee fixes for Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,5 +33,7 @@ WriteMakefile(
 		     author => ['Mark Summerfield <summer@perlpress.com>',
 				'Slaven Rezic <srezic@cpan.org',
 			       ],
-		   }) : ()),
+		   },
+		MIN_PERL_VERSION => '5.5.0',
+		LICENSE          => 'gpl_2') : ()),
 ) ;


### PR DESCRIPTION
Image::Xpm is my dist this month for the [CPAN PR Challenge](http://cpan-prc.org/) - thanks for taking part. Here are some simple fixes for three of the outstanding kwalitee issues.

As the POD simply says that the license is the GPL with no version identified I've set this to gpl_2 for now - is this a sensible default or is the correct license some other version?

I think that has_meta_json requires no changes to the source, just rebuilding the dist with a modern EUMM should be enough - it does on my copy anyway.

The only remaining non-experimental CPANTS issue is use_warnings. Is this something you would like to have added?