### PR TITLE
Update MANIFEST to include the new tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,5 +3,7 @@ Makefile.PL
 MANIFEST
 README
 t/const.t
+t/palette.t
+t/rgb2colour.t
 t/xpm.t
 Xpm.pm


### PR DESCRIPTION
I noticed that the new test scripts from #3 were not included in the 1.13 release. That's my fault for not updating the MANIFEST - sorry. This PR just corrects that error.